### PR TITLE
fix: repair release pipeline and reduce dependabot volume

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 10
+      interval: "monthly"
+    open-pull-requests-limit: 3
     labels:
       - "⬆️ dependencies"
     assignees:
@@ -22,32 +21,18 @@ updates:
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
     groups:
-      # Group all TypeScript/ESLint related updates
-      typescript-eslint:
-        patterns:
-          - "@typescript-eslint/*"
-          - "typescript"
-      # Group all Jest related updates
-      jest:
-        patterns:
-          - "jest*"
-          - "@types/jest"
-          - "ts-jest"
-      # Group development tools
-      dev-tools:
-        patterns:
-          - "prettier"
-          - "husky"
-          - "lint-staged"
-          - "eslint"
+      # Single group for all dev dependencies - one PR per cycle rather than
+      # several, since everything here is a build/test tool
+      dev-dependencies:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 2
     labels:
       - "⬆️ dependencies"
     assignees:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,14 +4,8 @@ on:
   push:
     branches:
       - 'main'
-    paths:
-      - '*.js'
-      - '*.mjs'
-      - '*.json'
-      - '*.ts'
-      - '*.md'
-      - 'docs/**'
-      - 'src/**'
+    # No paths filter: should_release already gates on commit type, and a filter
+    # here strands commits that only touch .github/**
 
 permissions:
   contents: write

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,4 +17,5 @@ jobs:
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Must be a PAT: merges made with GITHUB_TOKEN do not trigger build.yml
+          GH_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,5 +150,5 @@ jobs:
 
             ---
 
-            <sub>This PR will ${{ steps.version.outputs.should_release == 'true' && format('trigger a **{0}** version bump from `{1}` to `{2}`', steps.version.outputs.bump_type, steps.version.outputs.previous_version, steps.version.outputs.version) || 'not trigger a release (only docs/test/chore/build/ci/style/revert changes)' }}</sub>
+            <sub>Merging this PR will ${{ steps.version.outputs.should_release == 'true' && format('release a **{0}** bump, `{1}` → `{2}`. This covers everything unreleased on `main`, not only the commits in this PR.', steps.version.outputs.bump_type, steps.version.outputs.previous_version, steps.version.outputs.version) || 'not release (nothing unreleased on `main` beyond docs/test/chore/build/ci/style/revert changes)' }}</sub>
           comment-tag: version_impact


### PR DESCRIPTION
Closes #154. Closes #152.

Both issues live entirely in `.github/`, so they are handled together.

## Release pipeline (#154)

**1. Auto-merged pushes could not trigger `build.yml`** — `dependabot-auto-merge.yml` authenticated with `secrets.GITHUB_TOKEN`, and GitHub deliberately does not start workflow runs from events created with that token. Every auto-merged dependabot PR landed on `main` invisibly. Now uses `secrets.PAT`, which is present in this repo.

**3. `build.yml` path filter excluded `.github/**`** — filter dropped entirely. `should_release` already gates on commit type, so it added nothing except the failure mode that stranded the May workflow commits.

**2. Version Impact comment** — handled by wording rather than the fix the issue proposed. `actions/checkout` on a `pull_request` event checks out `refs/pull/N/merge`, so `HEAD` is already the PR merged into `main`, and the script's `${LATEST_TAG}..HEAD` reports exactly what merging this PR releases. That number was never wrong, only mislabelled as the work of the PR alone — and what made it *behave* wrong was defect 3, since the predicted release never actually happened. With the filter fixed it is accurate again, so only the description changes.

If isolating a PR's own contribution is wanted later, that is an additive feature rather than a fix to what #154 described.

## Dependabot volume (#152)

- `weekly` → `monthly` on both ecosystems (`day:` dropped, as it only applies to `weekly`)
- Four npm groups collapsed into one `dev-dependencies` group
- `open-pull-requests-limit` to 3 (npm) and 2 (github-actions)

Consolidating the four repos remains out of scope and tracked separately.

## Verification

YAML validated for all four files. After the next dependabot merge, confirm a Build run appears and its `triggering_actor` is not `jamiefdhurst` — if the PAT (dating from August 2024) has expired or lacks `repo` scope, this silently reverts to current behaviour with no error.