### PR TITLE
fix: do not auto-merge major dependency updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,9 +13,25 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          # Must be a PAT: merges made with GITHUB_TOKEN do not trigger build.yml
+          # Must be a PAT, and it must exist as a *Dependabot* secret as well as an
+          # Actions one - dependabot-triggered runs cannot see Actions secrets, and
+          # merges made with GITHUB_TOKEN do not trigger build.yml
+          GH_TOKEN: ${{ secrets.PAT }}
+      - name: Flag major update for manual review
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          echo "::notice::Major update to ${{ steps.metadata.outputs.dependency-names }} - not auto-merged, review and merge manually"
+          gh pr comment "$PR_URL" --body "🚧 Major version update — auto-merge is deliberately skipped. Review the changelog and merge manually."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.PAT }}


### PR DESCRIPTION
Follow-up to #159.

`dependabot-auto-merge.yml` had no update-type filter, so it merged anything dependabot opened once checks were green. That was masked while auto-merge was broken; now that it works, majors sail through unreviewed — `eslint` went 9.39.5 → 10.8.1 that way in #160.

Adds `dependabot/fetch-metadata@v3` and gates the merge on `update-type != version-update:semver-major`. Majors instead get a comment asking for manual review, so they do not sit silently. Minor and patch updates are unaffected.

v3 is current; its only breaking change from v2 is requiring the Node 24 Actions runtime — output names are unchanged.

Also documents on the token why the PAT must exist as a Dependabot secret, not only an Actions one — that gap is what broke #159 and what caused the earlier revert to `GITHUB_TOKEN`.