### PR TITLE
fix: handle undefined return from getCurrent in provider v2

### DIFF
--- a/src/__tests__/notes/provider.test.ts
+++ b/src/__tests__/notes/provider.test.ts
@@ -667,4 +667,34 @@ describe('Notes Provider', () => {
     expect(mockOpenFile).toHaveBeenCalledWith(expectedFile);
     expect(mockSetPinned).toHaveBeenCalled();
   });
+
+  it('does nothing when the current note has disappeared since being checked', async () => {
+    settings.alwaysOpen = true;
+    settings.daily.available = true;
+    settings.daily.enabled = true;
+    settings.daily.closeExisting = true;
+    settings.daily.open = true;
+
+    const mockDailyIsPresent = DailyNote.prototype.isPresent as jest.MockedFunction<
+      typeof DailyNote.prototype.isPresent
+    >;
+    mockDailyIsPresent.mockImplementation(() => true);
+    const mockGetCurrent = DailyNote.prototype.getCurrent as jest.MockedFunction<
+      typeof DailyNote.prototype.getCurrent
+    >;
+    // Published typedefs still declare TFile, though v2 returns TFile | undefined at runtime
+    mockGetCurrent.mockImplementation(() => undefined as never);
+    const mockDailyGetAllPaths = DailyNote.prototype.getAllPaths as jest.MockedFunction<
+      typeof DailyNote.prototype.getAllPaths
+    >;
+    const mockOpenFile = WorkspaceLeaf.prototype.openFile as jest.MockedFunction<
+      typeof WorkspaceLeaf.prototype.openFile
+    >;
+
+    await expect(sut.checkAndCreateNotes(settings)).resolves.not.toThrow();
+
+    expect(mockGetCurrent).toHaveBeenCalled();
+    expect(mockDailyGetAllPaths).not.toHaveBeenCalled();
+    expect(mockOpenFile).not.toHaveBeenCalled();
+  });
 });

--- a/src/notes/provider.ts
+++ b/src/notes/provider.ts
@@ -101,7 +101,12 @@ export default class NotesProvider {
         debug(
           `Set to always open notes, getting current ${term} note and checking if it needs to be opened`
         );
-        const existingNote: TFile = cls.getCurrent();
+        // getCurrent returns undefined if the note disappeared since isPresent() was checked
+        const existingNote: TFile | undefined = cls.getCurrent();
+        if (!existingNote) {
+          debug(`No current ${term} note found to open`);
+          return;
+        }
 
         await this.handleClose(setting, cls, existingNote);
         await this.handleOpen(setting, existingNote);


### PR DESCRIPTION
Closes #151.

The version bump the issue asks for had already landed — `package.json` and the lockfile are on `obsidian-periodic-notes-provider@2.0.0`. What was missing was the migration work, so this PR is the call-site half.

## The catch

v2 changed `getCurrent` / `getPrevious` to return `TFile | undefined`, but the **published `index.d.ts` still declares `getCurrent(): TFile`**. Only the TypeScript source carries the new signature. So `tsc` never flagged our call site, and the repo has been building clean against a contract it no longer satisfies.

`src/notes/provider.ts` assigned the result straight to `TFile` and passed it to `handleClose`, which dereferences `newNote.path`. Verified by temporarily removing the guard:

```
TypeError: Cannot read properties of undefined (reading 'path')
```

## Scope

Only the `alwaysOpen` branch is affected — `getPrevious` is not used anywhere in `src/`.

The undefined path is narrow: `isPresent()` and `getCurrent()` resolve the same date (`getDate()` already applies `startOf(unit)`, so they agree), and each calls `getAllNotes()` separately. It needs the note to disappear between the two calls. Rare, but it is exactly what the new signature exists to express, and the failure is a hard throw rather than a degraded result.

## Verification

- New test asserts the branch is a no-op, and fails with the `TypeError` above when the guard is removed
- `npm run lint`, `npm run build`, full suite: 56 passed (was 55)

## Note for the consolidation work

The stale `index.d.ts` is an upstream bug in `obsidian-periodic-notes-provider`. Worth fixing there — until it is, no consumer gets type-level help on this breaking change, `obsidian-auto-tasks` on v2 included.