### PR TITLE
ci: attest build provenance for release assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
 permissions:
   contents: write
   id-token: write
+  # Required to record provenance attestations for the release assets
+  attestations: write
 
 jobs:
   Build:
@@ -67,6 +69,14 @@ jobs:
       - name: Build
         if: steps.version.outputs.should_release == 'true'
         run: npm run build
+      - name: Attest Build Provenance
+        if: steps.version.outputs.should_release == 'true'
+        uses: actions/attest-build-provenance@v4
+        with:
+          # Both files are published as release assets, so both are attested
+          subject-path: |
+            main.js
+            manifest.json
       - name: Generate Release Notes
         if: steps.version.outputs.should_release == 'true'
         id: release_notes


### PR DESCRIPTION
Addresses the remaining item from the Obsidian plugin review: release assets have no artifact attestations.

Adds `actions/attest-build-provenance@v4` to `build.yml`, so each release records signed provenance proving the assets were built from this repository by this workflow. Users can verify with:

```
gh attestation verify main.js --repo jamiefdhurst/obsidian-auto-periodic-notes
```

## Details

- **Placement** — runs after `npm run build` and before `Create Release`, so the attested bytes are exactly the bytes uploaded. Nothing modifies either file in between: `manifest.json` is already committed by the version step earlier in the job.
- **Subjects** — `main.js` and `manifest.json`. The review flags only `main.js`, but both are published as release assets, so both are attested.
- **Permissions** — adds `attestations: write`. The action also needs `id-token: write`, which the workflow already had.
- **Gating** — carries the same `should_release` condition as the surrounding steps, so nothing runs on non-releasing pushes.

Attestations are free for public repositories, and this repo is public.

Verification is on the next release: the run must show the attestation step succeeding, and `gh attestation verify` must pass against the published `main.js`. A green build alone is not sufficient evidence, since a missing permission would surface as a failure in that step specifically.