### PR TITLE
feat: make the Periodic Notes plugin optional

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,6 +1,6 @@
 repository:
   name: obsidian-auto-periodic-notes
-  description: Obsidian plugin to create new periodic notes automatically in the background and allow these to be pinned in your open tabs. Requires the "Periodic Notes" plugin.
+  description: Obsidian plugin to create new periodic notes automatically in the background and allow these to be pinned in your open tabs. Optionally uses the "Periodic Notes" plugin.
   topics: obsidian, typescript, plugin, notes, pkm
   private: false
   has_issues: true

--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 
 Creates new periodic notes automatically in the background and allows these to be pinned in your open tabs; supports daily, weekly, monthly, quarterly and yearly notes.
 
-Designed to work with [Obsidian](https://obsidian.md), requires the [Periodic Notes](https://github.com/liamcain/obsidian-periodic-notes) plugin.
+Designed to work with [Obsidian](https://obsidian.md). The [Periodic Notes](https://github.com/liamcain/obsidian-periodic-notes) plugin is optional.
 
-_Note: this now supports the current (**v0.0.17**) and newer Beta (**v1.0.0-beta3**) versions of Periodic Notes available via [BRAT](https://tfthacker.com/BRAT). This functionality is provided through a [abstract provider](https://github.com/jamiefdhurst/obsidian-periodic-notes-provider) for the required plugin._
+_Note: this supports the current (**v0.0.17**) and newer Beta (**v1.0.0-beta3**) versions of Periodic Notes available via [BRAT](https://tfthacker.com/BRAT), as well as running without that plugin at all. This functionality is provided through an [abstract provider](https://github.com/jamiefdhurst/obsidian-periodic-notes-provider)._
 
-This plugin respects the settings of the Periodic Notes plugin, creating your notes using the templates, format and location you have selected.
+When the Periodic Notes plugin is installed, this plugin respects its settings, creating your notes using the templates, format and location you have selected.
+
+## Running without the Periodic Notes plugin
+
+If the Periodic Notes plugin isn't installed, all five note types are still available and are created using Obsidian's own defaults - `YYYY-MM-DD` for daily, `gggg-[W]ww` for weekly (or your [Calendar](https://github.com/liamcain/obsidian-calendar-plugin) plugin settings, if you have it), `YYYY-MM` for monthly, `YYYY-[Q]Q` for quarterly and `YYYY` for yearly, each in the vault root with no template. Your daily notes also pick up the settings from Obsidian's built-in Daily Notes core plugin.
+
+Which of those note types you actually want created remains entirely up to this plugin's own settings - nothing is turned on for you.
 
 ## Features
 
@@ -37,7 +43,7 @@ These are run by spawning the `git` binary already installed on your machine, vi
 
 ![Example of Settings screen within Obsidian](/docs/settings.png)
 
-Automatic creation can be toggled on and off for each of the supported note types, these are only shown if you have enabled and configured these notes within the Periodic Notes plugin. Within each note type, you can set whether to open and pin the note automatically, or whether to simply create it in the background, showing a notice when complete.
+Automatic creation can be toggled on and off for each of the supported note types. If you have the Periodic Notes plugin installed, only the note types you have enabled and configured there are shown; without it, all five are available. Within each note type, you can set whether to open and pin the note automatically, or whether to simply create it in the background, showing a notice when complete.
 
 ## Development
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Auto Periodic Notes",
   "version": "1.2.3",
   "minAppVersion": "1.13.0",
-  "description": "Creates new periodic notes automatically in the background and allows these to be pinned in your open tabs, requires the Periodic Notes plugin.",
+  "description": "Creates new periodic notes automatically in the background and allows these to be pinned in your open tabs, optionally using the Periodic Notes plugin.",
   "author": "Jamie Hurst",
   "authorUrl": "https://jamiehurst.co.uk",
   "isDesktopOnly": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "obsidian-auto-periodic-notes",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-auto-periodic-notes",
-      "version": "1.2.1",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
-        "obsidian-periodic-notes-provider": "^2.0.0"
+        "obsidian-periodic-notes-provider": "^2.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -8058,9 +8058,9 @@
       "license": "0BSD"
     },
     "node_modules/obsidian-periodic-notes-provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/obsidian-periodic-notes-provider/-/obsidian-periodic-notes-provider-2.0.0.tgz",
-      "integrity": "sha512-KjsgGLcHyRTQ3obDwQB8Vh06YQ34pJLtlEa5Da7DkATVcH7jZbvXyiOwdB1gy/G7rjvzEJ2/iakWkiMN4oW8Aw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/obsidian-periodic-notes-provider/-/obsidian-periodic-notes-provider-2.1.0.tgz",
+      "integrity": "sha512-BNq8ulXxw4X6IwubImFeTpQXUoa72JLobm31FMlKcxtgO29HnF0bvipKMlYPJe0GizeoCBDQva6z8+rBI51ORA==",
       "license": "MIT",
       "dependencies": {
         "obsidian-daily-notes-interface": "0.9.5"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian-auto-periodic-notes",
   "version": "1.2.3",
-  "description": "Creates new periodic notes automatically in the background and allows these to be pinned in your open tabs, requires the Periodic Notes plugin.",
+  "description": "Creates new periodic notes automatically in the background and allows these to be pinned in your open tabs, optionally using the Periodic Notes plugin.",
   "main": "main.js",
   "scripts": {
     "dev": "node esbuild.config.mjs",
@@ -44,7 +44,7 @@
     "typescript-eslint": "^8.67.0"
   },
   "dependencies": {
-    "obsidian-periodic-notes-provider": "^2.0.0"
+    "obsidian-periodic-notes-provider": "^2.1.0"
   },
   "nano-staged": {
     "*.ts": [

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,9 +1,24 @@
 import { readFileSync } from 'fs';
 import { PluginManifest, Vault } from 'obsidian';
+import { PeriodicNotesPluginAdapter } from 'obsidian-periodic-notes-provider';
 import AutoPeriodicNotes from '../';
 import { SETTINGS_UPDATED } from '../events';
 import { DEFAULT_SETTINGS } from '../settings';
 import { ObsidianApp, ObsidianWorkspace } from '../types';
+
+jest.mock('obsidian-periodic-notes-provider');
+
+const adapterMock = PeriodicNotesPluginAdapter as jest.MockedClass<
+  typeof PeriodicNotesPluginAdapter
+>;
+
+const allAvailable = {
+  daily: { available: true },
+  weekly: { available: true },
+  monthly: { available: true },
+  quarterly: { available: true },
+  yearly: { available: true },
+};
 
 describe('AutoPeriodicNotes', () => {
   let app: ObsidianApp;
@@ -12,15 +27,29 @@ describe('AutoPeriodicNotes', () => {
   let sut: AutoPeriodicNotes;
 
   beforeEach(() => {
+    adapterMock.mockClear();
     app = jest.fn() as unknown as ObsidianApp;
     workspace = jest.fn() as unknown as ObsidianWorkspace;
     workspace.onLayoutReady = jest.fn();
     workspace.trigger = jest.fn();
+    workspace.on = jest.fn();
     app.vault = jest.fn() as unknown as Vault;
     app.workspace = workspace;
+    app.plugins = { enabledPlugins: new Set<string>() } as ObsidianApp['plugins'];
     manifest = JSON.parse(readFileSync(__dirname + '/../../manifest.json', 'utf-8'));
     sut = new AutoPeriodicNotesTestable(app, manifest);
   });
+
+  /**
+   * The adapter is constructed in the plugin constructor, so its behaviour has
+   * to be staged before the subject under test is rebuilt.
+   */
+  const givenAdapter = (isNative: boolean): void => {
+    adapterMock.prototype.isNative = jest.fn().mockReturnValue(isNative);
+    adapterMock.prototype.isEnabled = jest.fn().mockReturnValue(!isNative);
+    adapterMock.prototype.convertSettings = jest.fn().mockReturnValue(allAvailable);
+    sut = new AutoPeriodicNotesTestable(app, manifest);
+  };
 
   it('loads settings', async () => {
     await sut.loadSettings();
@@ -60,6 +89,28 @@ describe('AutoPeriodicNotes', () => {
 
     await expect(sut.updateSettings(sut.settings)).resolves.toBeUndefined();
   });
+
+  it('continues to load when the Periodic Notes plugin is not installed', async () => {
+    givenAdapter(true);
+    await sut.loadSettings();
+
+    sut.onLayoutReady();
+
+    // Availability comes from the native fallback rather than the plugin
+    expect(sut.settings.daily.available).toBe(true);
+    expect(sut.settings.yearly.available).toBe(true);
+    expect(sut.addSettingTab).toHaveBeenCalled();
+  });
+
+  it('loads normally when the Periodic Notes plugin is installed', async () => {
+    givenAdapter(false);
+    await sut.loadSettings();
+
+    sut.onLayoutReady();
+
+    expect(adapterMock.prototype.convertSettings).toHaveBeenCalled();
+    expect(sut.addSettingTab).toHaveBeenCalled();
+  });
 });
 
 class AutoPeriodicNotesTestable extends AutoPeriodicNotes {
@@ -69,6 +120,10 @@ class AutoPeriodicNotesTestable extends AutoPeriodicNotes {
     this.app = app;
     this.manifest = manifest;
   }
+  addSettingTab = jest.fn();
+  registerEvent = jest.fn();
+  registerInterval = jest.fn();
+  initialRun = jest.fn().mockResolvedValue(undefined);
   loadData(): Promise<any> {
     return Promise.resolve(DEFAULT_SETTINGS);
   }

--- a/src/__tests__/notes/provider.test.ts
+++ b/src/__tests__/notes/provider.test.ts
@@ -682,8 +682,7 @@ describe('Notes Provider', () => {
     const mockGetCurrent = DailyNote.prototype.getCurrent as jest.MockedFunction<
       typeof DailyNote.prototype.getCurrent
     >;
-    // Published typedefs still declare TFile, though v2 returns TFile | undefined at runtime
-    mockGetCurrent.mockImplementation(() => undefined as never);
+    mockGetCurrent.mockImplementation(() => undefined);
     const mockDailyGetAllPaths = DailyNote.prototype.getAllPaths as jest.MockedFunction<
       typeof DailyNote.prototype.getAllPaths
     >;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Notice, Plugin, type PluginManifest } from 'obsidian';
+import { Plugin, type PluginManifest } from 'obsidian';
 import {
   PERIODIC_NOTES_EVENT_SETTING_UPDATED,
   PeriodicNotesPluginAdapter,
@@ -41,12 +41,13 @@ export default class AutoPeriodicNotes extends Plugin {
   }
 
   onLayoutReady(): void {
-    if (!this.periodicNotesPlugin.isEnabled()) {
-      new Notice(
-        'The Periodic Notes plugin must be installed and available for Auto Periodic Notes to work.',
-        10000
+    // The Periodic Notes plugin is optional - when it is absent the provider
+    // falls back to the native obsidian-daily-notes-interface defaults, so the
+    // plugin still works, it just has no external settings source to read from
+    if (this.periodicNotesPlugin.isNative()) {
+      debug(
+        'Periodic Notes plugin is not available, falling back to native periodic note defaults'
       );
-      return;
     }
 
     debug('Starting initial layout and load');
@@ -120,7 +121,9 @@ export default class AutoPeriodicNotes extends Plugin {
   }
 
   private syncPeriodicNotesSettings(): void {
-    debug('Received new settings from Periodic Notes plugin');
+    // Resolves against the Periodic Notes plugin when it is installed, and
+    // against the native defaults otherwise - either way this never throws
+    debug('Resolving the available periodic note types');
     const pluginSettings = this.periodicNotesPlugin.convertSettings();
     this.settings.daily.available = pluginSettings.daily.available;
     this.settings.weekly.available = pluginSettings.weekly.available;

--- a/src/notes/provider.ts
+++ b/src/notes/provider.ts
@@ -5,7 +5,7 @@ import debug from '../log';
 import {
   DailyNote,
   MonthlyNote,
-  Note,
+  PeriodicNote,
   QuarterlyNote,
   WeeklyNote,
   YearlyNote,
@@ -69,7 +69,7 @@ export default class NotesProvider {
 
   private async checkAndCreateSingleNote(
     setting: IPeriodicitySettings,
-    cls: Note,
+    cls: PeriodicNote,
     term: string,
     alwaysOpen: boolean,
     processTemplater: boolean
@@ -129,7 +129,7 @@ export default class NotesProvider {
 
   private async handleClose(
     setting: IPeriodicitySettings,
-    cls: Note,
+    cls: PeriodicNote,
     newNote: TFile
   ): Promise<void> {
     if (setting.closeExisting) {


### PR DESCRIPTION
Fixes #153 

Updates `obsidian-periodic-notes-provider` to 2.1.0 and drops the hard requirement on the Periodic Notes plugin.

## What changed upstream

**Native fallback.** `PeriodicNotesPluginAdapter` gained `isNative()`, and `convertSettings()` no longer throws when the plugin is missing — it falls back to a new `NativeProvider` and reports all five periodicities as available. Notes were already created through `obsidian-daily-notes-interface`, which supplies its own defaults for every granularity (`YYYY-MM-DD`, `gggg-[W]ww`, `YYYY-MM`, `YYYY-[Q]Q`, `YYYY`, vault root, no template), so the machinery for this was already in place.

**`Note` is gone.** 2.0.0 shipped a hand-written `index.d.ts` exporting an abstract `Note`; 2.1.0 ships generated declarations where the base class is `PeriodicNote`. The old name silently degraded to `any`, which was masking type errors in `notes/provider.ts` — those surfaced as 14 `no-unsafe-*` lint errors on the bump.

## Changes here

- `src/index.ts` — `onLayoutReady` no longer bails out with a notice when the plugin is absent. It debug-logs the fallback via `isNative()` and carries on.
- `src/notes/provider.ts` — `Note` → `PeriodicNote`.
- `src/__tests__/notes/provider.test.ts` — dropped an `undefined as never` cast; `getCurrent()` is now correctly declared `TFile | undefined`, so the workaround became a lint error.
- `src/__tests__/index.test.ts` — `onLayoutReady` had no coverage at all. Added tests for both the native and plugin-installed paths.
- `manifest.json`, `package.json`, `.github/settings.yml` — descriptions no longer claim the plugin is required.
- `README.md` — reworked intro plus a new section documenting the native defaults.

## Notes for review

- **Nothing is auto-enabled.** In native mode all five report `available: true`, but `enabled` stays false, so no notes are created until the user opts in per type. This matches the provider's intent that the choice belongs to the consuming plugin.
- **The settings-tab banner is untouched.** Its "turn one on within the Periodic Notes plugin settings" text is now only reachable when the plugin *is* installed with nothing enabled, so it stays accurate. In native mode it's hidden.
- Typed `feat:` for a minor bump, per `COMMIT_CONVENTION.md`.

Lint, typecheck, build and all 58 tests pass locally.

https://claude.ai/code/session_01155aH91Vizo12HWQGXsKi5
