### PR TITLE
feat: allow notes to be created at the end of their period

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Which of those note types you actually want created remains entirely up to this 
 - Supports opening and pinning the new notes automatically when created
 - Supports automatically closing older notes
 - Can exclude weekends from daily note generation
+- Can create weekly, monthly, quarterly and yearly notes at the end of their period rather than the start, which suits review notes
 - Optionally commits and pushes your vault to git at the end of each day (desktop only, off by default)
 
 ## Automatic git commits
@@ -44,6 +45,24 @@ These are run by spawning the `git` binary already installed on your machine, vi
 ![Example of Settings screen within Obsidian](/docs/settings.png)
 
 Automatic creation can be toggled on and off for each of the supported note types. If you have the Periodic Notes plugin installed, only the note types you have enabled and configured there are shown; without it, all five are available. Within each note type, you can set whether to open and pin the note automatically, or whether to simply create it in the background, showing a notice when complete.
+
+### Choosing when in the period a note is created
+
+Weekly, monthly, quarterly and yearly notes have a **Create new notes on** setting, with three choices, each named after the period itself - a monthly note offers "First day of the month", a yearly note "First day of the year", and so on:
+
+| Option       | When the note is created                                        |
+| ------------ | --------------------------------------------------------------- |
+| First day    | At the start of the period. This is the default.                |
+| Last weekday | On the last Monday to Friday within the period.                 |
+| Last day     | On the final day of the period, whether or not it is a weekday. |
+
+This changes only _when_ the note is created, never which note it is or how it is dated — August's monthly note is still August's monthly note. Creating a note at the end of its period suits reviews, where you want the period to have happened before you write anything.
+
+Each option shows the date it lands on for the current period, so you can see all three side by side before choosing - for example "Last weekday of the month (Mon 31 Aug)".
+
+Weekly notes follow your vault's configured week start, so with a week running Monday to Sunday, "first day" is Monday, "last weekday" is Friday and "last day" is Sunday.
+
+Daily notes do not have this setting, since it would have no effect.
 
 ## Development
 

--- a/src/__tests__/notes/provider.test.ts
+++ b/src/__tests__/notes/provider.test.ts
@@ -28,6 +28,7 @@ describe('Notes Provider', () => {
         closeExisting: false,
         open: false,
         pin: false,
+        createOn: 'first-day',
         excludeWeekends: false,
       },
       weekly: {
@@ -36,6 +37,7 @@ describe('Notes Provider', () => {
         closeExisting: false,
         open: false,
         pin: false,
+        createOn: 'first-day',
       },
       monthly: {
         available: false,
@@ -43,6 +45,7 @@ describe('Notes Provider', () => {
         closeExisting: false,
         open: false,
         pin: false,
+        createOn: 'first-day',
       },
       quarterly: {
         available: false,
@@ -50,6 +53,7 @@ describe('Notes Provider', () => {
         closeExisting: false,
         open: false,
         pin: false,
+        createOn: 'first-day',
       },
       yearly: {
         available: false,
@@ -57,6 +61,7 @@ describe('Notes Provider', () => {
         closeExisting: false,
         open: false,
         pin: false,
+        createOn: 'first-day',
       },
       gitCommit: false,
       gitCommitMessage: '',
@@ -215,6 +220,95 @@ describe('Notes Provider', () => {
     expect(mockDailyIsPresent).toHaveBeenCalled();
     expect(mockDailyCreate).toHaveBeenCalled();
     expect(Notice).toHaveBeenCalledWith(`Today's daily note has been created.`, 5000);
+  });
+
+  it('does not create a monthly note set to the last day until that day arrives', async () => {
+    settings.monthly.available = true;
+    settings.monthly.enabled = true;
+    settings.monthly.createOn = 'last-day';
+
+    const mockMonthlyIsPresent = MonthlyNote.prototype.isPresent as jest.MockedFunction<
+      typeof MonthlyNote.prototype.isPresent
+    >;
+    mockMonthlyIsPresent.mockImplementation(() => false);
+    const spyMonthlyCreate = jest.spyOn(MonthlyNote.prototype, 'create');
+
+    // Mid-August, so the note is not due until the 31st
+    jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-17T12:00:00Z').getTime());
+
+    await sut.checkAndCreateNotes(settings);
+
+    expect(mockMonthlyIsPresent).toHaveBeenCalled();
+    expect(spyMonthlyCreate).not.toHaveBeenCalled();
+  });
+
+  it('creates a monthly note set to the last day once that day arrives', async () => {
+    settings.monthly.available = true;
+    settings.monthly.enabled = true;
+    settings.monthly.createOn = 'last-day';
+
+    const mockMonthlyIsPresent = MonthlyNote.prototype.isPresent as jest.MockedFunction<
+      typeof MonthlyNote.prototype.isPresent
+    >;
+    mockMonthlyIsPresent.mockImplementation(() => false);
+    const mockMonthlyCreate = MonthlyNote.prototype.create as jest.MockedFunction<
+      typeof MonthlyNote.prototype.create
+    >;
+    mockMonthlyCreate.mockImplementation(() => Promise.resolve(new TFile()));
+
+    jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-31T09:00:00Z').getTime());
+
+    await sut.checkAndCreateNotes(settings);
+
+    expect(mockMonthlyIsPresent).toHaveBeenCalled();
+    expect(mockMonthlyCreate).toHaveBeenCalled();
+  });
+
+  it('creates notes set to the first day at any point in the period', async () => {
+    settings.yearly.available = true;
+    settings.yearly.enabled = true;
+    settings.yearly.createOn = 'first-day';
+
+    const mockYearlyIsPresent = YearlyNote.prototype.isPresent as jest.MockedFunction<
+      typeof YearlyNote.prototype.isPresent
+    >;
+    mockYearlyIsPresent.mockImplementation(() => false);
+    const mockYearlyCreate = YearlyNote.prototype.create as jest.MockedFunction<
+      typeof YearlyNote.prototype.create
+    >;
+    mockYearlyCreate.mockImplementation(() => Promise.resolve(new TFile()));
+
+    jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-17T12:00:00Z').getTime());
+
+    await sut.checkAndCreateNotes(settings);
+
+    expect(mockYearlyCreate).toHaveBeenCalled();
+  });
+
+  it('still opens an existing note that is set to be created later in its period', async () => {
+    settings.alwaysOpen = true;
+    settings.monthly.available = true;
+    settings.monthly.enabled = true;
+    settings.monthly.createOn = 'last-day';
+
+    const existing = new TFile();
+    existing.path = 'monthly/2026-08.md';
+
+    const mockMonthlyIsPresent = MonthlyNote.prototype.isPresent as jest.MockedFunction<
+      typeof MonthlyNote.prototype.isPresent
+    >;
+    mockMonthlyIsPresent.mockImplementation(() => true);
+    const mockMonthlyGetCurrent = MonthlyNote.prototype.getCurrent as jest.MockedFunction<
+      typeof MonthlyNote.prototype.getCurrent
+    >;
+    mockMonthlyGetCurrent.mockImplementation(() => existing);
+
+    // Mid-period, so creation is not due, but the note already exists
+    jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-17T12:00:00Z').getTime());
+
+    await sut.checkAndCreateNotes(settings);
+
+    expect(mockMonthlyGetCurrent).toHaveBeenCalled();
   });
 
   it('processes Templater code when creating new notes and setting is enabled', async () => {

--- a/src/__tests__/notes/schedule.test.ts
+++ b/src/__tests__/notes/schedule.test.ts
@@ -1,0 +1,125 @@
+import { moment } from 'obsidian';
+import { getCreationDate, isCreationDue } from '../../notes/schedule';
+import type { ICreateOn, IPeriodicity } from '../../settings';
+
+jest.mock('obsidian');
+
+const at = (date: string) => moment(date);
+
+describe('Notes Schedule', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('getCreationDate', () => {
+    it.each<[IPeriodicity, ICreateOn, string, string]>([
+      // First day of the period is unchanged from the original behaviour
+      ['monthly', 'first-day', '2026-08-17', '2026-08-01'],
+      ['quarterly', 'first-day', '2026-08-17', '2026-07-01'],
+      ['yearly', 'first-day', '2026-08-17', '2026-01-01'],
+
+      // Last day of the period
+      ['monthly', 'last-day', '2026-08-17', '2026-08-31'],
+      ['quarterly', 'last-day', '2026-08-17', '2026-09-30'],
+      ['yearly', 'last-day', '2026-08-17', '2026-12-31'],
+      ['monthly', 'last-day', '2026-02-10', '2026-02-28'],
+
+      // Last weekday steps back over a weekend, and stays put otherwise.
+      // August 2026 ends on a Monday, so both resolve to the 31st
+      ['monthly', 'last-weekday', '2026-08-17', '2026-08-31'],
+      // May 2026 ends on a Sunday, so it steps back to Friday the 29th
+      ['monthly', 'last-weekday', '2026-05-10', '2026-05-29'],
+      // October 2026 ends on a Saturday, stepping back to Friday the 30th
+      ['monthly', 'last-weekday', '2026-10-10', '2026-10-30'],
+      ['yearly', 'last-weekday', '2026-08-17', '2026-12-31'],
+    ])('resolves %s notes set to %s from %s as %s', (periodicity, createOn, now, expected) => {
+      expect(getCreationDate(periodicity, createOn, at(now)).format('YYYY-MM-DD')).toBe(expected);
+    });
+
+    it('resolves weekly notes against a Monday week start', () => {
+      // Wednesday 2026-08-19, in a week running Monday to Sunday
+      const now = at('2026-08-19').locale('en-gb');
+
+      expect(getCreationDate('weekly', 'first-day', now).format('dddd YYYY-MM-DD')).toBe(
+        'Monday 2026-08-17'
+      );
+      expect(getCreationDate('weekly', 'last-weekday', now).format('dddd YYYY-MM-DD')).toBe(
+        'Friday 2026-08-21'
+      );
+      expect(getCreationDate('weekly', 'last-day', now).format('dddd YYYY-MM-DD')).toBe(
+        'Sunday 2026-08-23'
+      );
+    });
+
+    it('resolves weekly notes against a Sunday week start', () => {
+      // The same Wednesday, in a week running Sunday to Saturday
+      const now = at('2026-08-19').locale('en');
+
+      expect(getCreationDate('weekly', 'first-day', now).format('dddd YYYY-MM-DD')).toBe(
+        'Sunday 2026-08-16'
+      );
+      expect(getCreationDate('weekly', 'last-weekday', now).format('dddd YYYY-MM-DD')).toBe(
+        'Friday 2026-08-21'
+      );
+      expect(getCreationDate('weekly', 'last-day', now).format('dddd YYYY-MM-DD')).toBe(
+        'Saturday 2026-08-22'
+      );
+    });
+
+    it('falls back to the first day for settings saved before the option existed', () => {
+      expect(
+        getCreationDate('monthly', undefined as unknown as ICreateOn, at('2026-08-17')).format(
+          'YYYY-MM-DD'
+        )
+      ).toBe('2026-08-01');
+    });
+
+    it('does not mutate the date it is given', () => {
+      const now = at('2026-08-17');
+      getCreationDate('monthly', 'last-day', now);
+
+      expect(now.format('YYYY-MM-DD')).toBe('2026-08-17');
+    });
+  });
+
+  describe('isCreationDue', () => {
+    it('is always due when set to the first day of the period', () => {
+      expect(isCreationDue('monthly', 'first-day', at('2026-08-01'))).toBe(true);
+      expect(isCreationDue('monthly', 'first-day', at('2026-08-17'))).toBe(true);
+      expect(isCreationDue('monthly', 'first-day', at('2026-08-31'))).toBe(true);
+    });
+
+    it('holds back a monthly note until the last day of the month', () => {
+      expect(isCreationDue('monthly', 'last-day', at('2026-08-01'))).toBe(false);
+      expect(isCreationDue('monthly', 'last-day', at('2026-08-30'))).toBe(false);
+      expect(isCreationDue('monthly', 'last-day', at('2026-08-31'))).toBe(true);
+    });
+
+    it('is due at any point on the configured day, not only at midnight', () => {
+      expect(isCreationDue('monthly', 'last-day', at('2026-08-31T23:30:00'))).toBe(true);
+      expect(isCreationDue('monthly', 'last-day', at('2026-08-31T00:00:00'))).toBe(true);
+    });
+
+    it('remains due for the rest of the period once the configured day has passed', () => {
+      // May 2026 ends on a Sunday, so the last weekday is Friday the 29th
+      expect(isCreationDue('monthly', 'last-weekday', at('2026-05-28'))).toBe(false);
+      expect(isCreationDue('monthly', 'last-weekday', at('2026-05-29'))).toBe(true);
+      expect(isCreationDue('monthly', 'last-weekday', at('2026-05-30'))).toBe(true);
+      expect(isCreationDue('monthly', 'last-weekday', at('2026-05-31'))).toBe(true);
+    });
+
+    it('holds back quarterly and yearly notes until the end of their period', () => {
+      expect(isCreationDue('quarterly', 'last-day', at('2026-08-17'))).toBe(false);
+      expect(isCreationDue('quarterly', 'last-day', at('2026-09-30'))).toBe(true);
+      expect(isCreationDue('yearly', 'last-day', at('2026-09-30'))).toBe(false);
+      expect(isCreationDue('yearly', 'last-day', at('2026-12-31'))).toBe(true);
+    });
+
+    it('defaults to the current date', () => {
+      jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-17T12:00:00Z').getTime());
+
+      expect(isCreationDue('monthly', 'first-day')).toBe(true);
+      expect(isCreationDue('monthly', 'last-day')).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/settings/index.test.ts
+++ b/src/__tests__/settings/index.test.ts
@@ -35,6 +35,34 @@ describe('settings', () => {
     expect(result.gitCommit).toEqual(true);
   });
 
+  it('fills in periodicity keys that are missing from saved settings', () => {
+    // Settings saved before "createOn" existed carry every other key, so a
+    // shallow merge over the defaults would leave it undefined
+    const settings = {
+      daily: { available: true, enabled: true, closeExisting: false, open: false, pin: false },
+      monthly: { available: true, enabled: true, closeExisting: false, open: false, pin: false },
+    } as ISettings;
+
+    const result = applyDefaultSettings(settings);
+
+    expect(result.daily.createOn).toEqual('first-day');
+    expect(result.daily.excludeWeekends).toEqual(false);
+    expect(result.monthly.createOn).toEqual('first-day');
+    expect(result.monthly.enabled).toEqual(true);
+    expect(result.yearly.createOn).toEqual('first-day');
+  });
+
+  it('keeps a saved createOn value', () => {
+    const settings = {
+      quarterly: { available: true, enabled: true, createOn: 'last-weekday' },
+    } as unknown as ISettings;
+
+    const result = applyDefaultSettings(settings);
+
+    expect(result.quarterly.createOn).toEqual('last-weekday');
+    expect(result.quarterly.pin).toEqual(false);
+  });
+
   it('migrates "openAndPin" setting into new format', () => {
     const settings = {
       daily: {

--- a/src/__tests__/settings/tab.test.ts
+++ b/src/__tests__/settings/tab.test.ts
@@ -119,6 +119,8 @@ describe('settings tab', () => {
     expect(displayed).toContain('Close older daily notes');
     expect(displayed).toContain('Exclude weekends');
     expect(displayed).not.toContain('Enable automatic weekly notes');
+    // Choosing a day within the period is meaningless for daily notes
+    expect(displayed).not.toContain('Create new daily notes on');
   });
 
   it('displays settings for weekly periodicity', () => {
@@ -133,6 +135,40 @@ describe('settings tab', () => {
     expect(displayed).toContain('Close older weekly notes');
     expect(displayed).not.toContain('Exclude weekends');
     expect(displayed).not.toContain('Enable automatic monthly notes');
+    expect(displayed).toContain('Create new weekly notes on');
+  });
+
+  it('names the options after the period and resolves each to a date', () => {
+    plugin.settings.quarterly.available = true;
+    jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-17T12:00:00Z').getTime());
+
+    const setting = find(sut.getSettingDefinitions(), 'Create new quarterly notes on');
+
+    expect(setting.control.options).toEqual({
+      'first-day': 'First day of the quarter (Wed 1 Jul)',
+      'last-weekday': 'Last weekday of the quarter (Wed 30 Sep)',
+      'last-day': 'Last day of the quarter (Wed 30 Sep)',
+    });
+  });
+
+  it('resolves the option dates without regard to which one is selected', () => {
+    plugin.settings.monthly.available = true;
+    jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-17T12:00:00Z').getTime());
+
+    // The dates must be identical whichever option is currently stored, so
+    // that they stay correct without the tab re-rendering on every change
+    plugin.settings.monthly.createOn = 'first-day';
+    const before = find(sut.getSettingDefinitions(), 'Create new monthly notes on');
+
+    plugin.settings.monthly.createOn = 'last-day';
+    const after = find(sut.getSettingDefinitions(), 'Create new monthly notes on');
+
+    expect(after.control.options).toEqual(before.control.options);
+    expect(after.control.options['last-day']).toEqual('Last day of the month (Mon 31 Aug)');
+
+    // The description must not depend on the selection either
+    expect(after.desc).toEqual(before.desc);
+    expect(after.desc).toContain('Choose when during the month');
   });
 
   it('displays settings for all periodicities', () => {
@@ -179,6 +215,18 @@ describe('settings tab', () => {
     for (const dependent of dependents) {
       expect(dependent.control.disabled()).toBe(false);
     }
+  });
+
+  it('disables the create on setting until the note type is enabled', () => {
+    plugin.settings.monthly.available = true;
+
+    const createOn = find(sut.getSettingDefinitions(), 'Create new monthly notes on');
+
+    expect(createOn.control.disabled()).toBe(true);
+
+    plugin.settings.monthly.enabled = true;
+
+    expect(createOn.control.disabled()).toBe(false);
   });
 
   it('disables pinning until the note type is enabled and set to open', () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,17 @@
+import type { unitOfTime } from 'moment';
 import { IPeriodicity } from './settings';
 
 export const periodicities: IPeriodicity[] = ['daily', 'weekly', 'monthly', 'quarterly', 'yearly'];
+
+/**
+ * The moment unit that each periodicity spans. These match the units used by
+ * obsidian-periodic-notes-provider, so that a period resolved here always
+ * covers exactly the same span as the note the provider would create for it.
+ */
+export const periodicityUnits: Record<IPeriodicity, unitOfTime.StartOf> = {
+  daily: 'day',
+  weekly: 'week',
+  monthly: 'month',
+  quarterly: 'quarter',
+  yearly: 'year',
+};

--- a/src/notes/provider.ts
+++ b/src/notes/provider.ts
@@ -1,5 +1,5 @@
 import { moment, Notice, type TFile, type WorkspaceLeaf, type App } from 'obsidian';
-import { IDailySettings, IPeriodicitySettings, ISettings } from '../settings';
+import { IDailySettings, IPeriodicity, IPeriodicitySettings, ISettings } from '../settings';
 import { ObsidianWorkspace } from '../types';
 import debug from '../log';
 import {
@@ -11,6 +11,7 @@ import {
   YearlyNote,
 } from 'obsidian-periodic-notes-provider';
 import { processTemplaterInFile } from '../templater';
+import { isCreationDue } from './schedule';
 
 const DEFAULT_WAIT_TIMEOUT: number = 1000;
 
@@ -70,7 +71,7 @@ export default class NotesProvider {
   private async checkAndCreateSingleNote(
     setting: IPeriodicitySettings,
     cls: PeriodicNote,
-    term: string,
+    term: IPeriodicity,
     alwaysOpen: boolean,
     processTemplater: boolean
   ): Promise<void> {
@@ -83,6 +84,14 @@ export default class NotesProvider {
             debug('Not creating new note as it is a weekend');
             return;
           }
+        }
+
+        // Notes set to be created later in their period are held back until
+        // that day arrives - this is always the current period's note, so
+        // nothing about which note gets created changes here
+        if (!isCreationDue(term, setting.createOn)) {
+          debug(`Not creating new ${term} note yet, as it is not due until later in the period`);
+          return;
         }
 
         debug(`Creating new ${term} note`);

--- a/src/notes/schedule.ts
+++ b/src/notes/schedule.ts
@@ -1,0 +1,65 @@
+import type { Moment } from 'moment';
+import { moment } from 'obsidian';
+import { periodicityUnits } from '../constants';
+import type { ICreateOn, IPeriodicity } from '../settings';
+
+const SUNDAY: number = 0;
+const SATURDAY: number = 6;
+
+/**
+ * Resolves the day within the current period on which the note should be
+ * created. Weekly periods follow the vault's configured week start, because
+ * `startOf`/`endOf` use the same moment locale that the notes provider uses to
+ * decide which week a note belongs to.
+ *
+ * @param periodicity - The note type being scheduled
+ * @param createOn - Which day of the period was configured
+ * @param now - The reference date, used to locate the current period
+ * @returns The start of the day on which creation is due
+ */
+export function getCreationDate(
+  periodicity: IPeriodicity,
+  createOn: ICreateOn,
+  now: Moment
+): Moment {
+  const unit = periodicityUnits[periodicity];
+
+  if (createOn === 'last-day' || createOn === 'last-weekday') {
+    const date: Moment = now.clone().endOf(unit).startOf('day');
+
+    if (createOn === 'last-weekday') {
+      while (date.day() === SATURDAY || date.day() === SUNDAY) {
+        date.subtract(1, 'day');
+      }
+    }
+
+    return date;
+  }
+
+  // Anything else, including settings saved before this option existed, keeps
+  // the original behaviour of creating at the start of the period
+  return now.clone().startOf(unit);
+}
+
+/**
+ * Checks whether the current period's note is due to be created yet.
+ *
+ * Creation is due on the configured day and on any remaining day of the
+ * period, so that a note is still created if the vault was not opened on the
+ * day itself.
+ *
+ * @param periodicity - The note type being scheduled
+ * @param createOn - Which day of the period was configured
+ * @param now - The reference date, defaulting to the current date
+ * @returns True if the note should be created now, false if it is too early
+ */
+export function isCreationDue(
+  periodicity: IPeriodicity,
+  createOn: ICreateOn,
+  now: Moment = moment()
+): boolean {
+  return !now
+    .clone()
+    .startOf('day')
+    .isBefore(getCreationDate(periodicity, createOn, now));
+}

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -3,6 +3,13 @@ import { periodicities } from '../constants';
 
 export type IPeriodicity = 'daily' | 'weekly' | 'monthly' | 'quarterly' | 'yearly';
 
+/**
+ * When within its own period a note should be created. This never changes
+ * which note is created - it is always the note for the current period - only
+ * the point at which it appears.
+ */
+export type ICreateOn = 'first-day' | 'last-weekday' | 'last-day';
+
 export interface IPeriodicitySettings {
   available: boolean;
   enabled: boolean;
@@ -10,6 +17,7 @@ export interface IPeriodicitySettings {
   openAndPin?: boolean; // Deprecated: will be removed in a future breaking release
   open: boolean;
   pin: boolean;
+  createOn: ICreateOn;
 }
 
 export interface IDailySettings extends IPeriodicitySettings {
@@ -34,6 +42,7 @@ export const DEFAULT_PERIODICITY_SETTINGS: IPeriodicitySettings = Object.freeze(
   closeExisting: false,
   open: false,
   pin: false,
+  createOn: 'first-day',
 });
 
 export const DEFAULT_SETTINGS: ISettings = Object.freeze({
@@ -63,5 +72,19 @@ export function applyDefaultSettings(savedSettings: ISettings): ISettings {
     }
   }
 
-  return Object.assign({}, DEFAULT_SETTINGS, savedSettings);
+  const settings = Object.assign({}, DEFAULT_SETTINGS, savedSettings);
+
+  // The merge above is shallow, so a saved periodicity replaces the default
+  // object wholesale and any key added since it was saved would be missing.
+  // Re-apply the per-periodicity defaults underneath what was saved.
+  const merged = settings as unknown as Record<string, IPeriodicitySettings>;
+  for (const periodicity of periodicities) {
+    merged[periodicity] = Object.assign(
+      {},
+      DEFAULT_SETTINGS[periodicity],
+      savedSettings?.[periodicity]
+    );
+  }
+
+  return settings;
 }

--- a/src/settings/tab.ts
+++ b/src/settings/tab.ts
@@ -1,7 +1,9 @@
-import { App, PluginSettingTab, type SettingDefinitionItem } from 'obsidian';
+import { App, moment, PluginSettingTab, type SettingDefinitionItem } from 'obsidian';
 import AutoPeriodicNotes from '..';
-import { periodicities } from '../constants';
+import { periodicities, periodicityUnits } from '../constants';
+import { getCreationDate } from '../notes/schedule';
 import { TEMPLATER_PLUGIN } from '../templater';
+import type { ICreateOn, IPeriodicity } from '../settings';
 import type { ObsidianApp } from '../types';
 
 export default class AutoPeriodicNotesSettingsTab extends PluginSettingTab {
@@ -88,7 +90,22 @@ export default class AutoPeriodicNotesSettingsTab extends PluginSettingTab {
                   },
                 },
               ]
-            : []),
+            : [
+                {
+                  // Creating the note later in its period suits review-style
+                  // notes, which need the period to have happened first
+                  name: `Create new ${periodicity} notes on`,
+                  // Deliberately says nothing about the selected option, so
+                  // that it cannot fall out of step with the dropdown
+                  desc: `Choose when during the ${periodicityUnits[periodicity]} the note is created.`,
+                  control: {
+                    type: 'dropdown' as const,
+                    key: `${periodicity}.createOn`,
+                    options: this.createOnOptions(periodicity),
+                    disabled: () => !this.plugin.settings[periodicity].enabled,
+                  },
+                },
+              ]),
           {
             name: `Open new ${periodicity} notes`,
             desc: 'Automatically open the new note when created.',
@@ -159,6 +176,30 @@ export default class AutoPeriodicNotesSettingsTab extends PluginSettingTab {
 
     // Re-evaluate the `disabled` predicates, e.g. pin depends on open
     this.refreshDomState();
+  }
+
+  /**
+   * Names the option choices after the period itself, so that a monthly note
+   * offers "First day of the month" rather than a generic "period", and
+   * resolves each one against the current period so the day it lands on is
+   * visible - weekly notes in particular depend on the vault's week start.
+   *
+   * The dates live on the options rather than in a description because the
+   * options do not depend on which one is selected, so they show the right
+   * dates without the tab having to re-render when the choice changes. It
+   * also puts all three dates side by side when choosing between them.
+   */
+  private createOnOptions(periodicity: IPeriodicity): Record<string, string> {
+    const period = periodicityUnits[periodicity];
+    const now = moment();
+    const on = (createOn: ICreateOn): string =>
+      getCreationDate(periodicity, createOn, now).format('ddd D MMM');
+
+    return {
+      'first-day': `First day of the ${period} (${on('first-day')})`,
+      'last-weekday': `Last weekday of the ${period} (${on('last-weekday')})`,
+      'last-day': `Last day of the ${period} (${on('last-day')})`,
+    };
   }
 
   private isAnyPeriodicityAvailable(): boolean {


### PR DESCRIPTION
Closes #167.

Adds a **Create new notes on** setting to weekly, monthly, quarterly and yearly notes, with three choices: the first day of the period, the last weekday, or the last day. This suits review-style notes, which need the period to have happened before there is anything to write — a monthly review can now appear on the 31st rather than the 1st.

Daily notes are excluded, since the option would have no effect there.

## How it works

The note created is always the **current period's** note, dated as it always was — August's monthly note is still August's monthly note. Only the point at which it is created changes, so no changes to `obsidian-periodic-notes-provider` are needed; `create()` already creates the note for the period containing now.

`src/notes/schedule.ts` resolves the configured day within the current period, and the provider gains a single early return before the existing `create()` call. Creation is due on the chosen day **and on any remaining day of the period**, so a note is still created if the vault was not opened on the day itself.

The default, `first-day`, is exactly the existing behaviour.

## Settings UI

```
Create new monthly notes on              [ First day of the month (Sat 1 Aug) ▾ ]
Choose when during the month the note is created.
                                           First day of the month (Sat 1 Aug)
                                           Last weekday of the month (Mon 31 Aug)
                                           Last day of the month (Mon 31 Aug)
```

Options are named after the period itself, and each resolves to the date it lands on so all three can be compared before choosing. The dates sit on the options rather than in the description deliberately: they do not depend on which option is selected, so they stay correct without the tab needing to re-render when the choice changes. A test asserts this property directly.

Weekly notes follow the vault's configured week start, so with a Monday-start week "first day" is Monday, "last weekday" is Friday and "last day" is Sunday. Tests cover both Monday-start and Sunday-start locales.

## Also fixed

`applyDefaultSettings` merged saved settings shallowly, so a saved periodicity object replaced the default wholesale and any key added since it was last saved would come back `undefined`. It now re-applies the per-periodicity defaults underneath the saved values. This was already latent for `excludeWeekends`; adding `createOn` would have hit every existing user.